### PR TITLE
Fix building

### DIFF
--- a/src/memorymap.cc
+++ b/src/memorymap.cc
@@ -188,7 +188,7 @@ private:
 		info.GetReturnValue().Set(buf.ToLocalChecked());
 	}
 
-	static inline Nan::Persistent<v8::Function>& constructor() {
+	static inline Nan::Persistent<v8::Function> &constructor() {
 		static Nan::Persistent<v8::Function> my_constructor;
 		return my_constructor;
 	}

--- a/src/memorymap.cc
+++ b/src/memorymap.cc
@@ -183,7 +183,7 @@ private:
 			}
 		}
 		Nan::MaybeLocal<v8::Object> buf = Nan::CopyBuffer(data, len);
-		obj->pos_ += (DWORD)len + bufLength;
+		obj->pos_ += (DWORD) len + bufLength;
 		info.GetReturnValue().Set(buf.ToLocalChecked());
 	}
 

--- a/src/memorymap.cc
+++ b/src/memorymap.cc
@@ -156,7 +156,7 @@ private:
 			return;
 		}
 		Nan::MaybeLocal<v8::Object> buf = Nan::CopyBuffer(data, len);
-		obj->pos_ += (DWORD)len;
+		obj->pos_ += (DWORD) len;
 		info.GetReturnValue().Set(buf.ToLocalChecked());
 	}
 
@@ -187,7 +187,7 @@ private:
 		info.GetReturnValue().Set(buf.ToLocalChecked());
 	}
 
-	static inline Nan::Persistent<v8::Function> &constructor() {
+	static inline Nan::Persistent<v8::Function> & constructor() {
 		static Nan::Persistent<v8::Function> my_constructor;
 		return my_constructor;
 	}

--- a/src/memorymap.cc
+++ b/src/memorymap.cc
@@ -109,11 +109,10 @@ private:
 	static NAN_METHOD(New) {
 		if (info.IsConstructCall()) {
 			Nan::Utf8String utf8_value(info[0]);
-			MemoryMap* obj = new MemoryMap(utf8_value);
+			MemoryMap *obj = new MemoryMap(utf8_value);
 			obj->Wrap(info.This());
 			info.GetReturnValue().Set(info.This());
-		}
-		else {
+		} else {
 			const int argc = 1;
 			v8::Local<v8::Value> argv[argc] = { info[0] };
 			v8::Local<v8::Function> cons = Nan::New(constructor());

--- a/src/memorymap.cc
+++ b/src/memorymap.cc
@@ -11,7 +11,7 @@ std::wstring to_utf16(const Nan::Utf8String& str) {
 	if (lengthRequired > 0) {
 		std::wstring converted;
 		converted.resize(static_cast<size_t>(lengthRequired));
-		::MultiByteToWideChar(CP_UTF8, 0, text, static_cast<int>(length), (LPWSTR)converted.data(), lengthRequired);
+		::MultiByteToWideChar(CP_UTF8, 0, text, static_cast<int>(length), (LPWSTR) converted.data(), lengthRequired);
 		return converted;
 	}
 	return {};


### PR DESCRIPTION
This PR fixes build failure:
```
PS C:\projects\kek\memory-map> npm run build

> memory-map@1.1.0 build C:\projects\kek\memory-map
> node-gyp build


C:\projects\kek\memory-map>if not defined npm_config_node_gyp (node "C:\Program Files\nodejs\node_modules\npm\node_modules\npm-lifecycle\node-gyp-bin\\..\..\node_modules\node-gyp\bin\node-gyp.js" build )  else (node "C:\Program Files\nodejs\node_modules\npm\node_modules\node-gyp\bin\node-gyp.js" build )
Building the projects in this solution one at a time. To enable parallel build, please add the "-m" switch.
  memorymap.cc
C:\projects\kek\memory-map\src\memorymap.cc(130,1): error C2660: 'v8::Value::Uint32Value': function does not take 0 arg
uments [C:\projects\kek\memory-map\build\memorymap.vcxproj]
C:\Users\Pospelov\AppData\Local\node-gyp\Cache\14.16.0\include\node\v8.h(2866,41): message : see declaration of 'v8::Va
lue::Uint32Value' [C:\projects\kek\memory-map\build\memorymap.vcxproj]
C:\projects\kek\memory-map\src\memorymap.cc(153,1): error C2660: 'v8::Value::Uint32Value': function does not take 0 arg
uments [C:\projects\kek\memory-map\build\memorymap.vcxproj]
C:\Users\Pospelov\AppData\Local\node-gyp\Cache\14.16.0\include\node\v8.h(2866,41): message : see declaration of 'v8::Va
lue::Uint32Value' [C:\projects\kek\memory-map\build\memorymap.vcxproj]
C:\projects\kek\memory-map\src\memorymap.cc(167,1): error C2660: 'v8::Value::ToObject': function does not take 0 argume
nts [C:\projects\kek\memory-map\build\memorymap.vcxproj]
C:\Users\Pospelov\AppData\Local\node-gyp\Cache\14.16.0\include\node\v8.h(2822,44): message : see declaration of 'v8::Va
lue::ToObject' [C:\projects\kek\memory-map\build\memorymap.vcxproj]
```